### PR TITLE
Docs passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Local
 __pycache__
 pyaplus.egg-info
-docs
+venv
+docs/_build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,30 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PyAPLUS
+
+[![Documentation Status](https://readthedocs.org/projects/pyaplus-docs/badge/?version=latest)](https://pyaplus-docs.readthedocs.io/en/latest/?badge=latest)
+
 Abstraction layer over the COM ASPEN PLUS interface using Python. If you can though, and I cannot recommend this enough, use HYSYS. The state is absolute pre-alpha right now, and it is only able to make reading some properties from streams quicker and to access them without that much code.
 
 ## Installation
@@ -18,7 +21,8 @@ pip install -e .
 </pre>
 
 ## Closing the simulation
-Aspen Plus does not behave as nicely as HYSYS. Therefore, there is a forced closure programmed as the default that kills the task in the windows task manager, and all tasks with a shared name, i.e., AspenPlus.exe. If this is too extreme for you, you can remove this behavior by passing an argument to the `Simulation.close()` method, in the form `Simulation.close(soft = True)`. This probably will leave an Aspen Plus task in the background. If someone finds a less drastic way to make sure that Aspen Plus closes when you tell it to, I'm all ears. 
+
+Aspen Plus does not behave as nicely as HYSYS. Therefore, there is a forced closure programmed as the default that kills the task in the windows task manager, and all tasks with a shared name, i.e., AspenPlus.exe. If this is too extreme for you, you can remove this behavior by passing an argument to the `Simulation.close()` method, in the form `Simulation.close(soft = True)`. This probably will leave an Aspen Plus task in the background. If someone finds a less drastic way to make sure that Aspen Plus closes when you tell it to, I'm all ears.
 
 ## win32 DLL problem
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'pyaplus'
+copyright = '2022, Daniel Vázquez Vázquez'
+author = 'Daniel Vázquez Vázquez'
+release = '0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.coverage',
+              'sphinx_rtd_theme',
+]
+
+# templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+
+# GitHub integration
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "DanielVazVaz", # Username
+    "github_repo": "PyAPLUS", # Repo name
+    "github_version": "master", # Version
+    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. pyaplus documentation master file, created by
+   sphinx-quickstart on Tue Oct 11 23:58:46 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pyaplus's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+PyAPLUS
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   pyaplus

--- a/docs/pyaplus.rst
+++ b/docs/pyaplus.rst
@@ -1,0 +1,8 @@
+pyaplus.flowsheet
+------------------------
+
+.. automodule:: pyaplus.flowsheet
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==5.2.3
+sphinx-rtd-theme==1.0.0

--- a/pyaplus/flowsheet.py
+++ b/pyaplus/flowsheet.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import win32com.client as win32
 import subprocess
 
 
@@ -9,7 +8,10 @@ class Simulation:
     Args:
         path (str): String with the raw path to the Aspen PLUS file.
     """ 
-    def __init__(self, path: str) -> None:       
+    def __init__(self, path: str) -> None:     
+        
+        import win32com.client as win32  
+        
         self.path = path
         self.case = win32.Dispatch('Apwn.Document')
         self.case.InitFromArchive2(path)
@@ -176,11 +178,9 @@ class ProcessStream:
             "FLOW": Total flow. Depends on FLOWBASIS
             "FLOWBASIS": Basis of the total flow. Allowed values are "MASS", "MOLE", "STDVOL", or "VOLUME"
             ("COMFLOW", "chemical"): Component flow. Depends on COMPBASIS
-            "COMPBASIS": Basis of the composition window. It can be "MASS-FLOW", "MOLE-FLOW", "STDVOL-FLOW",
-                                "MASS-FRAC", "MOLE-FRAC", "STDVOL-FRAC", "MASS-CONC" or"MOLE-CONC" 
+            "COMPBASIS": Basis of the composition window. It can be "MASS-FLOW", "MOLE-FLOW", "STDVOL-FLOW", "MASS-FRAC", "MOLE-FRAC", "STDVOL-FRAC", "MASS-CONC" or"MOLE-CONC" 
             "VAPFRAC": Vapor fraction
-            "FLASHTYPE": Type of the data that the streams requires. Options are "TP", "TV", or "PV", where P is pressure,
-                         T is temperature, and V is vapor fraction
+            "FLASHTYPE": Type of the data that the streams requires. Options are "TP", "TV", or "PV", where P is pressure, T is temperature, and V is vapor fraction
         """
         match_dict = {"TEMP": r"TEMP\MIXED",
                       "PRES": r"PRES\MIXED",


### PR DESCRIPTION
Hey Daniel,

I am opening this PR to propose minimalistic working documentation for your package. With the files as they are in `docs` you should have no problems uploading to [readthedocs](https://readthedocs.org). In case you have any issues, let me know :)

P.S.: changed `import win32com.client as win32`  in the scope of the `flowsheet.py` file to the `Simulation` class, as in PySIS PR. I tested the modification here, but you should test it more since there are no unit tests for this package.

Kind regards,
Lucas.